### PR TITLE
Clean up responses in indexer instances

### DIFF
--- a/packages/framework/src/services/indexer/src/dal/entityRequestResponse.ts
+++ b/packages/framework/src/services/indexer/src/dal/entityRequestResponse.ts
@@ -1,5 +1,6 @@
 import { EntityStorage, EntityUpdateOp } from '@aleph-indexer/core'
 import { IndexableEntityType, ParsedEntity } from '../../../../types.js'
+import * as console from 'console'
 
 export type EntitySignatureResponse = {
   id: string
@@ -56,6 +57,9 @@ export function createEntityRequestResponseDAL<T extends ParsedEntity<unknown>>(
       newEntity: EntityRequestResponse<T>,
     ): Promise<EntityUpdateOp> {
       if (oldEntity) {
+        if (!newEntity.nonceIndexes) {
+          return EntityUpdateOp.Delete
+        }
         const nonceIndexes = {
           ...oldEntity.nonceIndexes,
           ...newEntity.nonceIndexes,

--- a/packages/framework/src/services/indexer/src/dal/entityRequestResponse.ts
+++ b/packages/framework/src/services/indexer/src/dal/entityRequestResponse.ts
@@ -1,6 +1,5 @@
 import { EntityStorage, EntityUpdateOp } from '@aleph-indexer/core'
 import { IndexableEntityType, ParsedEntity } from '../../../../types.js'
-import * as console from 'console'
 
 export type EntitySignatureResponse = {
   id: string


### PR DESCRIPTION
Problem: indexer instances would get too fat with requestResponseDAL data

Solution: remove responses when all assigned request nonces have been cleared (when the response has been processed, it removes its nonce from the response)