### PR TITLE
Fix invalid ranges when merging them

### DIFF
--- a/packages/framework/src/utils/time.ts
+++ b/packages/framework/src/utils/time.ts
@@ -180,6 +180,17 @@ export async function mergeDateRangesFromIterable(
   let prevMerged = false
 
   for await (const range of mergeRanges) {
+    // @note: Fix invalid ranges
+    if (range.endDate < range.startDate) {
+      const fixedRange = {
+        startDate: range.endDate,
+        endDate: range.endDate,
+      }
+      oldRanges.push(range)
+      newRanges.push(fixedRange)
+      continue
+    }
+
     if (!prevRange) {
       prevRange = range
       continue


### PR DESCRIPTION
Currently, statistics calculation will re-trigger every second on accounts that have only a single event. This ties in with issue #30.

This quick fix solves, at least, this infinite retry loop and some instances of incorrect values. The incorrect values were usually in the form of `DateRanges`, where the `startDate` is one ms _after_ the `endDate`, therefore resulting in an invalid `Interval`.

I will continue to search for the reason for these invalid `DateRanges`, this PR doesn't necessarily need to be merged, if the true reason for this behavior is found.