### PR TITLE
Fix accountState query when only has one transaction

### DIFF
--- a/packages/core/src/utils/concurrence/common.ts
+++ b/packages/core/src/utils/concurrence/common.ts
@@ -9,7 +9,7 @@ import { sleep } from '../time.js'
  */
 export async function concurrentPromises<T>(
   it: Iterator<Promise<unknown>, T>,
-  concurrency: number = 20,
+  concurrency = 20,
 ): Promise<T> {
   let done
   let lastValue!: T
@@ -118,7 +118,7 @@ export class Mutex {
 /**
  * An util for retaining a unique snapshot of data while
  * the previous snapshot is being processed.
- * 
+ *
  * Example:
  * ```ts
  * const job = new DebouncedJob<string>(async (data) => {
@@ -126,10 +126,10 @@ export class Mutex {
  *  console.log(data)
  *  return data
  * }, 1000)
- * 
+ *
  * job.run('foo')
  * ```
- * 
+ *
  * @param callback - The callback function that will be called with the data
  * @param throttle - The minimum time between calls
  */

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -41,11 +41,13 @@ export function splitDurationIntoIntervals(
     return []
   }
 
-  const length = startDate.equals(endDate) ? 1 : Math.ceil(
-    endDate
-      .diff(startDate, intervalUnit as DurationUnit)
-      .get(intervalUnit as DurationUnit) / intervalSize,
-  )
+  const length = startDate.equals(endDate)
+    ? 1
+    : Math.ceil(
+        endDate
+          .diff(startDate, intervalUnit as DurationUnit)
+          .get(intervalUnit as DurationUnit) / intervalSize,
+      )
 
   // Divide range (A, D) in chunks of intervalSize * intervalUnit time intervals
   // [(A, B), (B, C), (C, D)]

--- a/packages/framework/src/services/indexer/src/accountEntityIndexer.ts
+++ b/packages/framework/src/services/indexer/src/accountEntityIndexer.ts
@@ -102,14 +102,14 @@ export class BaseAccountEntityIndexer<T extends ParsedEntity<unknown>> {
     )
 
     const pendingMilis = pendingRanges.reduce(
-      (acc, curr) => acc + Math.max(
-        (curr.endDate - curr.startDate), 1
-      ), 0)
+      (acc, curr) => acc + Math.max(curr.endDate - curr.startDate, 1),
+      0,
+    )
 
     const processedMilis = processedRanges.reduce(
-      (acc, curr) => acc + Math.max(
-        (curr.endDate - curr.startDate), 1
-      ), 0)
+      (acc, curr) => acc + Math.max(curr.endDate - curr.startDate, 1),
+      0,
+    )
 
     const pending = pendingRanges.map((range) =>
       getIntervalFromDateRange(range).toISO(),

--- a/packages/framework/src/services/indexer/src/accountEntityIndexer.ts
+++ b/packages/framework/src/services/indexer/src/accountEntityIndexer.ts
@@ -102,14 +102,14 @@ export class BaseAccountEntityIndexer<T extends ParsedEntity<unknown>> {
     )
 
     const pendingMilis = pendingRanges.reduce(
-      (acc, curr) => acc + Math.abs(curr.endDate - curr.startDate),
-      0,
-    )
+      (acc, curr) => acc + Math.max(
+        (curr.endDate - curr.startDate), 1
+      ), 0)
 
     const processedMilis = processedRanges.reduce(
-      (acc, curr) => acc + Math.abs(curr.endDate - curr.startDate),
-      0,
-    )
+      (acc, curr) => acc + Math.max(
+        (curr.endDate - curr.startDate), 1
+      ), 0)
 
     const pending = pendingRanges.map((range) =>
       getIntervalFromDateRange(range).toISO(),

--- a/packages/framework/src/utils/stats/timeSeries.ts
+++ b/packages/framework/src/utils/stats/timeSeries.ts
@@ -124,10 +124,16 @@ export class TimeSeriesStats<I extends object, O> {
         trueDivideTimeFrameIndex--
       }
       if (timeFrame !== TimeFrame.All && trueDivideTimeFrameIndex > 0) {
-        const timeFrameSize = Duration.fromObject({[timeFrameName.toLowerCase()]: 1}).toMillis()
+        const timeFrameSize = Duration.fromObject({
+          [timeFrameName.toLowerCase()]: 1,
+        }).toMillis()
         while (true) {
           if (trueDivideTimeFrameIndex <= 0) break
-          const smallerSize = Duration.fromObject({[TimeFrame[sortedTimeFrames[trueDivideTimeFrameIndex]].toLowerCase()]: 1}).toMillis()
+          const smallerSize = Duration.fromObject({
+            [TimeFrame[
+              sortedTimeFrames[trueDivideTimeFrameIndex]
+            ].toLowerCase()]: 1,
+          }).toMillis()
           if (timeFrameSize % smallerSize === 0) break
           trueDivideTimeFrameIndex--
         }
@@ -259,7 +265,9 @@ export class TimeSeriesStats<I extends object, O> {
           let data: O | undefined
           for await (const value of inputs) {
             const input =
-              'data' in value && trueDivideTimeFrameIndex !== 0 ? value.data : value
+              'data' in value && trueDivideTimeFrameIndex !== 0
+                ? value.data
+                : value
             data = await aggregator({
               input,
               interval,

--- a/packages/indexer-example/src/domain/_mainWithStats.ts
+++ b/packages/indexer-example/src/domain/_mainWithStats.ts
@@ -6,13 +6,14 @@ import {
   AccountStatsFilters,
   AccountTimeSeriesStats,
   AccountStats,
-} from '@aleph-indexer/framework';
+} from '@aleph-indexer/framework'
 
 export default class MainDomain
   extends IndexerMainDomain
-  implements IndexerMainDomainWithStats {
+  implements IndexerMainDomainWithStats
+{
   constructor(protected context: IndexerMainDomainContext) {
-    super(context);
+    super(context)
   }
 
   // Implement the updateStats method
@@ -30,7 +31,7 @@ export default class MainDomain
     filters: AccountStatsFilters,
   ): Promise<AccountTimeSeriesStats[]> {
     // Logic for retrieving and transforming time-series stats for specified accounts
-    return [];
+    return []
   }
 
   // Implement the getAccountStats method
@@ -39,6 +40,6 @@ export default class MainDomain
     accounts: string[],
   ): Promise<AccountStats[]> {
     // Logic for retrieving global stats for specified accounts
-    return [];
+    return []
   }
 }


### PR DESCRIPTION
When an account has just a transaction, start and end range are the same, breaks further calculation for being 0, should be 1 at least